### PR TITLE
Update to display the correct HP values for De Rol Le and Barba Ray

### DIFF
--- a/Monster HP/init.lua
+++ b/Monster HP/init.lua
@@ -72,6 +72,41 @@ local function GetMonsterList()
                 mDisplay = false
             end
 
+            -- Handle De Rol Le's hitpoints as a special case
+            if mUnitxtID == 45 then
+                if i == 1 then
+                    mHP = pso.read_u16(mAddr + 0x6B4)
+                    mHPMax = pso.read_u16(mAddr + 0x6B0)
+                    table.insert(monsterList, { show = mDisplay, name = mName, HP = mHP, HPMax = mHPMax, color = mColor })
+
+                    mHP = pso.read_u16(mAddr + 0x6B8)
+                    mHPMax = mHP
+                    mName = mName .. " Skull"
+                else
+                    mHP = pso.read_u16(mAddr + 0x39C)
+                    mHPMax = mHP
+                    mName = mName .. " Shell"
+                end
+            end
+
+            -- Barba Ray generally works the same as
+            -- De Rol Le but uses different offsets
+            if mUnitxtID == 73 then
+                if i == 1 then
+                    mHP = pso.read_u16(mAddr + 0x704)
+                    mHPMax = pso.read_u16(mAddr + 0x700)
+                    table.insert(monsterList, { show = mDisplay, name = mName, HP = mHP, HPMax = mHPMax, color = mColor })
+
+                    mHP = pso.read_u16(mAddr + 0x708)
+                    mHPMax = mHP
+                    mName = mName .. " Skull"
+                else
+                    mHP = pso.read_u16(mAddr + 0x7AC)
+                    mHPMax = mHP
+                    mName = mName .. " Shell"
+                end
+            end
+
             table.insert(monsterList, { show = mDisplay, name = mName, HP = mHP, HPMax = mHPMax, color = mColor })
         end
     end


### PR DESCRIPTION
I hardcoded the HP lookups for De Rol Le and Barba Ray as special cases since I don't know if there's a more generic way to handle it. I couldn't find the max HP for the skull or the shells so I'm just setting max HP equal to HP in those cases, which works okay since the progress bar also displays numbers. I tested this against Normal/Online/De Rol Le, Normal/Online/Barba Ray, Normal/Offline/De Rol Le, Hard/Online/De Rol Le, and Ultimate/Online/Dal Ra Lie so I expect it to work for the full gamut.