### PR TITLE
Hide HP for monsters not in player's room

### DIFF
--- a/Monster HP/configuration.lua
+++ b/Monster HP/configuration.lua
@@ -6,6 +6,9 @@ local fontColor = 0xFFFFFFFF
 local fontSize = 1.0
 -- Invert the order of the monster list
 local invertMonsterList = false
+-- Hide HP bars for monsters that are
+-- not in the room that the player is in
+local showOnlyPlayerRoom = false
 
 return
 {
@@ -13,4 +16,5 @@ return
     fontColor = fontColor,
     fontSize = fontSize,
     invertMonsterList = invertMonsterList,
+    showOnlyPlayerRoom = showOnlyPlayerRoom,
 }

--- a/Monster HP/init.lua
+++ b/Monster HP/init.lua
@@ -43,6 +43,7 @@ local function CopyMonster(monster)
     local copy = {}
 
     copy.index    = monster.index
+    copy.room     = monster.room
     copy.posX     = monster.posX
     copy.posY     = monster.posY
     copy.posZ     = monster.posZ
@@ -114,6 +115,7 @@ local function GetMonsterData(monster)
     monster.unitxtID = pso.read_u32(monster.address + _MonsterUnitxtID)
     monster.HP = pso.read_u16(monster.address + _MonsterHP)
     monster.HPMax = pso.read_u16(monster.address + _MonsterHPMax)
+    monster.room = pso.read_u16(monster.address + _Room)
     monster.posX = pso.read_f32(monster.address + _PosX)
     monster.posY = pso.read_f32(monster.address + _PosY)
     monster.posZ = pso.read_f32(monster.address + _PosZ)
@@ -178,15 +180,13 @@ local function GetMonsterList()
             local xDist = math.abs(pPosX - monster.posX)
             local zDist = math.abs(pPosZ - monster.posZ)
             local tDist = math.sqrt(xDist ^ 2 + zDist ^ 2)
-        
+
             if cfgMonsters.maxDistance ~= 0 and tDist > cfgMonsters.maxDistance then
                 monster.display = false
             end
 
             -- Determine whether the player is in the same room as the monster
-            local monsterRoom = pso.read_u16(monster.address + _Room)
-
-            if cfg.showOnlyPlayerRoom and playerRoom ~= monsterRoom then
+            if cfg.showOnlyPlayerRoom and playerRoom ~= monster.room then
                 monster.display = false
             end
 

--- a/Monster HP/init.lua
+++ b/Monster HP/init.lua
@@ -9,6 +9,7 @@ local _PlayerCount = 0x00AAE168
 local _Difficulty = 0x00A9CD68
 local _Ultimate
 
+local _Room = 0x28
 local _PosX = 0x38
 local _PosY = 0x3C
 local _PosZ = 0x40
@@ -148,6 +149,7 @@ local function GetMonsterList()
     end
 
     -- Get player position
+    local playerRoom = pso.read_u16(pAddr + _Room)
     local pPosX = pso.read_f32(pAddr + _PosX)
     local pPosZ = pso.read_f32(pAddr + _PosZ)
 
@@ -178,6 +180,13 @@ local function GetMonsterList()
             local tDist = math.sqrt(xDist ^ 2 + zDist ^ 2)
         
             if cfgMonsters.maxDistance ~= 0 and tDist > cfgMonsters.maxDistance then
+                monster.display = false
+            end
+
+            -- Determine whether the player is in the same room as the monster
+            local monsterRoom = pso.read_u16(monster.address + _Room)
+
+            if cfg.showOnlyPlayerRoom and playerRoom ~= monsterRoom then
                 monster.display = false
             end
 


### PR DESCRIPTION
This adds the option in the Monster HP addon to hide HP bars for monsters that are not in the same room as the player.