### PR TITLE
Fixes for Floor Items addon

### DIFF
--- a/Floor Items/init.lua
+++ b/Floor Items/init.lua
@@ -291,6 +291,8 @@ local function ProcessMeseta(item)
         lib_helpers.TextC(false, lib_items_cfg.itemIndex, "% 3i", item.index)
         lib_helpers.TextC(false, lib_items_cfg.mesetaName, " %s", item.name)
         lib_helpers.TextC(false, lib_items_cfg.mesetaAmount, " %i", item.meseta)
+    else
+        imgui.SameLine(0, 0)
     end
 end
 

--- a/solylib/items/items.lua
+++ b/solylib/items/items.lua
@@ -77,7 +77,7 @@ local function _ParseItemWeapon(item)
     end
 
     item.weapon.grind = item.data[4]
-    item.weapon.special = item.data[5]
+    item.weapon.special = item.data[5] % 64
 
     item.weapon.isSRank = (item.data[2] >= 0x70 and item.data[2] < 0x89) or (item.data[2] >= 0xA5 and item.data[2] < 0xAA)
     -- SRANK

--- a/solylib/items/items.lua
+++ b/solylib/items/items.lua
@@ -71,7 +71,7 @@ local function _ParseItemWeapon(item)
         item.weapon.wrapped = true
         item.weapon.untekked = true
     elseif item.data[5] > 0x7F then
-        item.weapon.unteked = true
+        item.weapon.untekked = true
     elseif item.data[5] > 0x3F then
         item.weapon.wrapped = true
     end


### PR DESCRIPTION
Various fixes to the Floor Items addon.

* When the ignoreMeseta option is set to true, the addon would still add the newlines for the meseta to the overlay, leaving superfluous blank lines in the display.
* A typo when setting the `untekked` flag on weapons caused the addon to fail to display the `[U]` indicator to show that the item is untekked.
* The weapon special was not being masked properly. This logic was copied from the Character Reader addon and so is assumed to be correct. Testing seems to indicate that it works.