### PR TITLE
Add red flag for tekked-down blank attributes

### DIFF
--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -281,6 +281,9 @@ local function ProcessWeapon(item)
                     statColor = lib_items_cfg.weaponAttributes[i2 + 1]
                 end
             end
+            if item.weapon.statpresence[i - 1] == 1 and item.weapon.stats[i] == 0 then
+                statColor = lib_items_cfg.red
+            end
     
             result = result .. lib_helpers.TextC(false, statColor, "%i", stat)
     
@@ -297,6 +300,9 @@ local function ProcessWeapon(item)
             if stat <= lib_items_cfg.weaponHit[i2] then
                 statColor = lib_items_cfg.weaponHit[i2 + 1]
             end
+        end
+        if item.weapon.statpresence[5] == 1 and item.weapon.stats[6] == 0 then
+            statColor = lib_items_cfg.red
         end
         result = result .. lib_helpers.TextC(false, statColor, "%i", stat)
         result = result .. lib_helpers.TextC(false, lib_items_cfg.white, "] ")

--- a/solylib/items/items.lua
+++ b/solylib/items/items.lua
@@ -87,20 +87,24 @@ local function _ParseItemWeapon(item)
     -- NON SRANK
     else
         item.weapon.stats = {0,0,0,0,0,0}
+        item.weapon.statpresence = {0,0,0,0,0}
         if item.data[7] < 6 then
             item.weapon.stats[item.data[7] + 1] = item.data[8]
+            item.weapon.statpresence[item.data[7]] = 1
             if item.weapon.stats[item.data[7] + 1] > 127 then
                 item.weapon.stats[item.data[7] + 1] = item.weapon.stats[item.data[7] + 1] - 256
             end
         end
         if item.data[9] < 6 then
             item.weapon.stats[item.data[9] + 1] = item.data[10]
+            item.weapon.statpresence[item.data[9]] = 1
             if item.weapon.stats[item.data[9] + 1] > 127 then
                 item.weapon.stats[item.data[9] + 1] = item.weapon.stats[item.data[9] + 1] - 256
             end
         end
         if item.data[11] < 6 then
             item.weapon.stats[item.data[11] + 1] = item.data[12]
+            item.weapon.statpresence[item.data[11]] = 1
             if item.weapon.stats[item.data[11] + 1] > 127 then
                 item.weapon.stats[item.data[11] + 1] = item.weapon.stats[item.data[11] + 1] - 256
             end

--- a/solylib/items/items_configuration.lua
+++ b/solylib/items/items_configuration.lua
@@ -1,6 +1,7 @@
 -- All colors are 0xAARRGGBB
 local white = 0xFFFFFFFF
 local grey = 0xFFA0A0A0
+local red = 0xFFFF0000
 
 -- Item
 local itemIndex = 0xFFFFFFFF
@@ -131,6 +132,7 @@ return
     -- Colors
     white = white,
     grey = grey,
+    red = red,
     itemIndex = itemIndex,
     itemEquipped = itemEquipped,
     weaponUntekked = weaponUntekked,


### PR DESCRIPTION
Players can tekk an attribute down to 0 and that attribute still counts as a slot for sphering a weapon. This change makes it so a 0 attribute that was tekked down is highlighted in red, so a player can't say, for example, "selling 30h clean red saber" when it's really a Red Saber that had 5 A.Beast and 35 Hit, but was tekked down to 0 A.Beast and 30 Hit, making it so you couldn't add both Native and Machine to it. This change will be particularly useful if Trade Window reading is ever done.