### PR TITLE
Add invuln timer reading to Player Reader

### DIFF
--- a/Player Reader/configuration.lua
+++ b/Player Reader/configuration.lua
@@ -231,6 +231,11 @@ local function ConfigurationWindow(configuration)
                         this.changed = true
                     end
                     
+                    if imgui.Checkbox("Invulnerability", _configuration.players[i].Invulnerability) then
+                        _configuration.players[i].Invulnerability = not _configuration.players[i].Invulnerability
+                        this.changed = true
+                    end
+                    
                     imgui.TreePop()
                 end
             end

--- a/Player Reader/init.lua
+++ b/Player Reader/init.lua
@@ -58,6 +58,8 @@ if optionsLoaded then
         options.players[i].AlwaysAutoResize      = lib_helpers.NotNilOrDefault(options.players[i].AlwaysAutoResize, "AlwaysAutoResize")
         options.players[i].TransparentWindow     = lib_helpers.NotNilOrDefault(options.players[i].TransparentWindow, false)
         options.players[i].SD                    = lib_helpers.NotNilOrDefault(options.players[i].SD, true)
+        options.players[i].Invulnerability       = lib_helpers.NotNilOrDefault(options.players[i].Invulnerability, true)
+    
     end
 else
     options = 
@@ -101,6 +103,7 @@ else
         options.players[i].AlwaysAutoResize = "AlwaysAutoResize"
         options.players[i].TransparentWindow = false
         options.players[i].SD = true
+        options.players[i].Invulnerability = true
     end
 end
 
@@ -149,6 +152,7 @@ local function SaveOptions(options)
             io.write(string.format("            AlwaysAutoResize = \"%s\",\n", options.players[i].AlwaysAutoResize))
             io.write(string.format("            TransparentWindow = %s,\n", tostring(options.players[i].TransparentWindow)))
             io.write(string.format("            SD = %s,\n", tostring(options.players[i].SD)))
+            io.write(string.format("            Invulnerability = %s,\n", tostring(options.players[i].Invulnterability)))
             io.write(string.format("        },\n"))
         end
         io.write(string.format("    },\n"))
@@ -174,6 +178,7 @@ local function PresentPlayers()
         local hpColor = lib_helpers.HPToGreenRedGradient(hp/mhp)
         local atkTech = lib_characters.GetPlayerTechStatus(address, 0)
         local defTech = lib_characters.GetPlayerTechStatus(address, 1)
+        local invuln = lib_characters.GetPlayerInvulnStatus(address)
 
         lib_helpers.Text(true, "%2i", index)
         imgui.NextColumn()
@@ -191,11 +196,16 @@ local function PresentPlayers()
         else
             lib_helpers.Text(true, "%s %i: %s", defTech.name, defTech.level, os.date("!%M:%S", defTech.time))
         end
+        if invuln.name ~= "I" then
+            lib_helpers.Text(true, "---")
+        else
+            lib_helpers.Text(true, "%s: %s", invuln.name, os.date("!%M:%S", invuln.time))
+        end
         imgui.NextColumn()
     end
 end
 
-local function PresentPlayer(address, sd)
+local function PresentPlayer(address, sd, inv)
     if address == 0 then
         return
     end
@@ -208,6 +218,7 @@ local function PresentPlayer(address, sd)
     local mtp = lib_characters.GetPlayerMaxTP(address)
     local atkTech = lib_characters.GetPlayerTechStatus(address, 0)
     local defTech = lib_characters.GetPlayerTechStatus(address, 1)
+    local invuln = lib_characters.GetPlayerInvulnStatus(address)
 
     local hpColor = lib_helpers.HPToGreenRedGradient(hp/mhp)
     local tpColor = lib_helpers.HPToGreenRedGradient(tp/mtp)
@@ -251,6 +262,14 @@ local function PresentPlayer(address, sd)
             --lib_helpers.Text(true, "")
         else
             lib_helpers.Text(true, "%s %i: %s", defTech.name, defTech.level, os.date("!%M:%S", defTech.time))
+        end
+    end
+    
+    if inv == true then
+        if invuln.name ~= "I" then
+            --lib_helpers.Text(true, "")
+        else
+            lib_helpers.Text(true, "%s: %s", invuln.name, os.date("!%M:%S", invuln.time))
         end
     end
 end
@@ -334,7 +353,7 @@ local function present()
                             }
                         ) then
                             imgui.SetWindowFontScale(options.fontScale)
-                            PresentPlayer(address, options.players[i].SD)
+                            PresentPlayer(address, options.players[i].SD, options.players[i].Invulnerability)
 
                             if options.players[i].AlwaysAutoResize == "AlwaysAutoResize" then
                                 if options.players[i].Anchor == 3 or options.players[i].Anchor == 6 or options.players[i].Anchor == 9 then

--- a/solylib/characters.lua
+++ b/solylib/characters.lua
@@ -111,6 +111,25 @@ local function GetPlayerTechStatus(player, tech)
     }
 end
 
+local function GetPlayerInvulnStatus(player)
+    local frames = pso.read_u32(player + 0x720)
+    local time = tonumber(string.format("%.0f", frames / 30))
+    local totalTime = 30
+    
+    local name = "?"
+    if frames ~= 0 then
+        name = "I"
+    end
+    
+    return
+    {
+        frames = frames,
+        name = name,
+        time = time,
+        totalTime = totalTime
+    }
+end
+
 local function GetPlayerFrozenStatus(player)
     return pso.read_u32(player + 0x268) == 0x02
 end
@@ -133,6 +152,7 @@ return
     GetPlayerTP = GetPlayerTP,
     GetPlayerMaxTP = GetPlayerMaxTP,
     GetPlayerTechStatus = GetPlayerTechStatus,
+	GetPlayerInvulnStatus = GetPlayerInvulnStatus,
     GetPlayerFrozenStatus = GetPlayerFrozenStatus,
     GetPlayerConfusedStatus = GetPlayerConfusedStatus,
     GetPlayerParalyzedStatus = GetPlayerParalyzedStatus,


### PR DESCRIPTION
I tested this sort-of extensively with anime. There's a weird thing with hit-stun where the displayed value for other players doesn't line up with their client-side invuln timer, and where it jumps from 7 seconds to 2 when you stand up, but that's a PSO thing and not related to the addon. It's optional, anyway... I even added a new checkbox in the individual player reader!