### PR TITLE
Rectify issue of barriers not printing with stats

### DIFF
--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -585,7 +585,7 @@ local function ProcessBarrier(item, floor)
         end
 
         result = result .. lib_helpers.TextC(false, nameColor, "%s ", TrimString(item.name, options.itemNameLength))
-        writeArmorStats(item)
+        result = result .. writeArmorStats(item)
     end
 
     return result


### PR DESCRIPTION
Using the "Save to file" option does not export barriers with their stats, this small change corrects that