### PR TITLE
Display item count for inventory

### DIFF
--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -926,7 +926,7 @@ local function PresentInventory(save, index)
     end
     local itemCount = table.getn(cache_inventory.items)
 
-    lib_helpers.TextC(false, lib_items_cfg.itemIndex, "Meseta: %i", cache_inventory.meseta)
+    lib_helpers.TextC(false, lib_items_cfg.itemIndex, "Meseta: %i | Items: %i", cache_inventory.meseta, itemCount)
 
     for i=1,itemCount,1 do
         ProcessItem(cache_inventory.items[i], false, save)
@@ -939,7 +939,7 @@ local function PresentBank(save)
     end
     local itemCount = table.getn(cache_bank.items)
 
-    lib_helpers.TextC(false, lib_items_cfg.itemIndex, "Meseta: %i | Count: %i", cache_bank.meseta, itemCount)
+    lib_helpers.TextC(false, lib_items_cfg.itemIndex, "Meseta: %i | Items: %i", cache_bank.meseta, itemCount)
 
     for i=1,itemCount,1 do
         ProcessItem(cache_bank.items[i], false, save)


### PR DESCRIPTION
This displays the item count after the meseta count in the inventory tab, similar to the bank tab.

It would allow you to see how full your inventory is at a glance from the inventory tab.

I could try to add this as an option in the config menu instead if you prefer.