### PR TITLE
Implemented "multi-floor" option to Item Reader's Floor Reader and some '%' handling changes.

### DIFF
--- a/Item Reader/configuration.lua
+++ b/Item Reader/configuration.lua
@@ -85,7 +85,7 @@ local function ConfigurationWindow(configuration)
             if success then
                 this.changed = true
             end
-
+            
             imgui.TreePop()
         end
 
@@ -237,12 +237,27 @@ local function ConfigurationWindow(configuration)
 
             if imgui.Checkbox("Transparent window", _configuration.floor.TransparentWindow) then
                 _configuration.floor.TransparentWindow = not _configuration.floor.TransparentWindow
+                _configuration.floor.changed = true
                 this.changed = true
             end
             
             if imgui.Checkbox("Show inventory meseta and item count", _configuration.floor.ShowInvMesetaAndItemCount) then
                 _configuration.floor.ShowInvMesetaAndItemCount = not _configuration.floor.ShowInvMesetaAndItemCount
+                _configuration.floor.changed = true
                 this.changed = true
+            end
+
+            if imgui.Checkbox("Show items on all floors", _configuration.floor.ShowMultiFloor) then
+                _configuration.floor.ShowMultiFloor = not _configuration.floor.ShowMultiFloor
+                _configuration.floor.changed = true
+                this.changed = true
+            end
+            if _configuration.floor.ShowMultiFloor then
+                success, _configuration.floor.OtherFloorsBrightnessPercent = imgui.SliderInt("Text alpha percent", _configuration.floor.OtherFloorsBrightnessPercent, 0, 100)
+                if success then
+                    _configuration.floor.changed = true
+                    this.changed = true
+                end
             end
 
             if imgui.Checkbox("Enable Filters", _configuration.floor.EnableFilters) then

--- a/Item Reader/configuration.lua
+++ b/Item Reader/configuration.lua
@@ -274,7 +274,7 @@ local function ConfigurationWindow(configuration)
                     success, otherFloorIndicator = imgui.InputText("Prepend indicator string for other floors", _configuration.floor.OtherFloorsPrependString, 32)
                     if success then
                         -- Check if the string is safe to use (plugin updated). If not, then sanitize it.
-                        local canUseString = (pso.require_version ~= nil and pso.require_version(3,5,0))
+                        local canUseString = (pso.require_version ~= nil and pso.require_version(3, 6, 0))
                         if canUseString or string.find(otherFloorIndicator, "%%") == nil then
                             _configuration.floor.OtherFloorsPrependString = otherFloorIndicator
                             _configuration.floor.changed = true

--- a/Item Reader/configuration.lua
+++ b/Item Reader/configuration.lua
@@ -67,7 +67,9 @@ local function ConfigurationWindow(configuration)
                 this.changed = true
             end
 
+            imgui.PushItemWidth(100)
             success, _configuration.itemNameLength = imgui.InputInt("Max Item Name Length", _configuration.itemNameLength)
+            imgui.PopItemWidth()
             if success then
                 this.changed = true
             end
@@ -252,18 +254,42 @@ local function ConfigurationWindow(configuration)
                 _configuration.floor.changed = true
                 this.changed = true
             end
+
             if _configuration.floor.ShowMultiFloor then
-                imgui.PushItemWidth(100)
-                local enteredValue
-                success, enteredValue = imgui.InputInt("Brightness percent for other floors", _configuration.floor.OtherFloorsBrightnessPercent)
-                if success then
-                    if enteredValue >= 0 and enteredValue <= 100 then
-                        _configuration.floor.OtherFloorsBrightnessPercent = enteredValue
+                if imgui.TreeNodeEx("Multi-floor options") then
+                    imgui.PushItemWidth(100)
+                    local enteredValue
+                    success, enteredValue = imgui.InputInt("Brightness percent for other floors", _configuration.floor.OtherFloorsBrightnessPercent)
+                    if success then
+                        if enteredValue >= 0 and enteredValue <= 100 then
+                            _configuration.floor.OtherFloorsBrightnessPercent = enteredValue
+                        end
+                        _configuration.floor.changed = true
+                        this.changed = true
                     end
-                    _configuration.floor.changed = true
-                    this.changed = true
+                    imgui.PopItemWidth()
+                    
+                    imgui.PushItemWidth(100)
+                    local otherFloorIndicator
+                    success, otherFloorIndicator = imgui.InputText("Prepend indicator string for other floors", _configuration.floor.OtherFloorsPrependString, 32)
+                    if success then
+                        if string.find(otherFloorIndicator, "%%") == nil then
+                            _configuration.floor.OtherFloorsPrependString = otherFloorIndicator
+                            _configuration.floor.changed = true
+                            this.changed = true
+                        end
+                    end
+                    imgui.PopItemWidth()
+
+                    imgui.SameLine(0, 9)
+                    success = imgui.Button("Clear")
+                    if success then
+                        _configuration.floor.OtherFloorsPrependString = ""
+                        _configuration.floor.changed = true
+                        this.changed = true
+                    end
+                    imgui.TreePop()
                 end
-                imgui.PopItemWidth()
             end
 
             if imgui.Checkbox("Enable Filters", _configuration.floor.EnableFilters) then

--- a/Item Reader/configuration.lua
+++ b/Item Reader/configuration.lua
@@ -273,7 +273,9 @@ local function ConfigurationWindow(configuration)
                     local otherFloorIndicator
                     success, otherFloorIndicator = imgui.InputText("Prepend indicator string for other floors", _configuration.floor.OtherFloorsPrependString, 32)
                     if success then
-                        if string.find(otherFloorIndicator, "%%") == nil then
+                        -- Check if the string is safe to use (plugin updated). If not, then sanitize it.
+                        local canUseString = (pso.require_version ~= nil and pso.require_version(3,5,0))
+                        if canUseString or string.find(otherFloorIndicator, "%%") == nil then
                             _configuration.floor.OtherFloorsPrependString = otherFloorIndicator
                             _configuration.floor.changed = true
                             this.changed = true

--- a/Item Reader/configuration.lua
+++ b/Item Reader/configuration.lua
@@ -253,11 +253,17 @@ local function ConfigurationWindow(configuration)
                 this.changed = true
             end
             if _configuration.floor.ShowMultiFloor then
-                success, _configuration.floor.OtherFloorsBrightnessPercent = imgui.SliderInt("Text alpha percent", _configuration.floor.OtherFloorsBrightnessPercent, 0, 100)
+                imgui.PushItemWidth(100)
+                local enteredValue
+                success, enteredValue = imgui.InputInt("Brightness percent for other floors", _configuration.floor.OtherFloorsBrightnessPercent)
                 if success then
+                    if enteredValue >= 0 and enteredValue <= 100 then
+                        _configuration.floor.OtherFloorsBrightnessPercent = enteredValue
+                    end
                     _configuration.floor.changed = true
                     this.changed = true
                 end
+                imgui.PopItemWidth()
             end
 
             if imgui.Checkbox("Enable Filters", _configuration.floor.EnableFilters) then

--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -367,7 +367,7 @@ local function PrependMultifloorStringToItem(item)
 
         -- Handle '%' again if someone hasn't updated their plugin or if they manually edited options.lua.
         -- Check if we can use
-        local canUseString = (pso.require_version ~= nil and pso.require_version(3,5,0))
+        local canUseString = (pso.require_version ~= nil and pso.require_version(3, 6, 0))
         local str = options.floor.OtherFloorsPrependString
         if canUseString or string.match(str, "%%") == nil then
             -- Either plugin supports the string as-is or the string is sanitized already

--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -992,14 +992,15 @@ local function PresentFloor()
     end
     local itemCount = table.getn(cache_floor)
 
-    --[[index = index or lib_items.Me
-    if last_inventory_time + update_delay < current_time or last_inventory_index ~= index or cache_inventory == nil then
-        cache_inventory = lib_items.GetInventory(index)
-        last_inventory_index = index
-        last_inventory_time = current_time
-    end]]
-
+    -- If user wants to display their meseta and inventory count, then go get the inventory cache. 
     if options.floor.ShowInvMesetaAndItemCount then
+        index = index or lib_items.Me
+        if last_inventory_time + update_delay < current_time or last_inventory_index ~= index or cache_inventory == nil then
+            cache_inventory = lib_items.GetInventory(index)
+            last_inventory_index = index
+            last_inventory_time = current_time
+        end
+
         local invItemCount = table.getn(cache_inventory.items)
         TextCWrapper(false, lib_items_cfg.itemIndex, "Meseta: %i | Items: %i / 30", cache_inventory.meseta, invItemCount)
     end

--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -364,15 +364,15 @@ local function PrependMultifloorStringToItem(item)
     local myFloor = lib_characters.GetCurrentFloorSelf()
     if (TextCWrapper and item and item.floorNumber and item.floorNumber ~= myFloor and
         options.floor.OtherFloorsPrependString and string.len(options.floor.OtherFloorsPrependString) > 0) then
-        -- Unfortunately replacing '%' with '%%' still isn't sufficient when using TextC because no variadic arg support.
-        -- The configuration window should have prevented this, but just in case someone modified options.lua and made
-        -- this mistake...
+
+        -- Handle '%' again if someone hasn't updated their plugin or if they manually edited options.lua.
+        -- Check if we can use
+        local canUseString = (pso.require_version ~= nil and pso.require_version(3,5,0))
         local str = options.floor.OtherFloorsPrependString
-        -- Try to find '%' character
-        if string.match(str, "%%") == nil then
-            -- Not found, safe to use
+        if canUseString or string.match(str, "%%") == nil then
+            -- Either plugin supports the string as-is or the string is sanitized already
             TextCWrapper(false, lib_items_cfg.white, "%s ", str)
-        end        
+        end
     end
 end
 

--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -992,23 +992,20 @@ local function PresentFloor()
     end
     local itemCount = table.getn(cache_floor)
 
-    index = index or lib_items.Me
+    --[[index = index or lib_items.Me
     if last_inventory_time + update_delay < current_time or last_inventory_index ~= index or cache_inventory == nil then
         cache_inventory = lib_items.GetInventory(index)
         last_inventory_index = index
         last_inventory_time = current_time
-    end
+    end]]
 
     if options.floor.ShowInvMesetaAndItemCount then
         local invItemCount = table.getn(cache_inventory.items)
         TextCWrapper(false, lib_items_cfg.itemIndex, "Meseta: %i | Items: %i / 30", cache_inventory.meseta, invItemCount)
     end
 
-    local myPlayer = lib_characters.GetSelf()
-    local myFloor = -1
-    if myPlayer ~= 0 then 
-        myFloor = lib_characters.GetPlayerFloor(myPlayer)
-    end
+    local myFloor = lib_characters.GetCurrentFloorSelf()
+
     for i=1,itemCount,1 do
         local item = cache_floor[i]
         -- If item isn't on the same floor, then it's from multifloor selection.

--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -1004,7 +1004,11 @@ local function PresentFloor()
         TextCWrapper(false, lib_items_cfg.itemIndex, "Meseta: %i | Items: %i / 30", cache_inventory.meseta, invItemCount)
     end
 
-    local myFloor = lib_characters.GetPlayerFloor(lib_characters.GetSelf())
+    local myPlayer = lib_characters.GetSelf()
+    local myFloor = -1
+    if myPlayer ~= 0 then 
+        myFloor = lib_characters.GetPlayerFloor(myPlayer)
+    end
     for i=1,itemCount,1 do
         local item = cache_floor[i]
         -- If item isn't on the same floor, then it's from multifloor selection.

--- a/Player Reader/init.lua
+++ b/Player Reader/init.lua
@@ -250,7 +250,7 @@ local function PresentPlayers()
 
         local name = lib_characters.GetPlayerName(address)
         -- Escape '%' in the name but only if the plugin isn't updated
-        if pso.require_version == nil or not pso.require_version(3, 5, 0) then
+        if pso.require_version == nil or not pso.require_version(3, 6, 0) then
             name = string.gsub(name, "%%", "%%%%")
         end
         local hp = lib_characters.GetPlayerHP(address)
@@ -292,7 +292,7 @@ local function PresentPlayer(address, sd, inv, showName, HPbar, showBarMaxValue,
 
     local name = lib_characters.GetPlayerName(address)
     -- Escape '%' in the name but only if the plugin isn't updated
-    if pso.require_version == nil or not pso.require_version(3, 5, 0) then
+    if pso.require_version == nil or not pso.require_version(3, 6, 0) then
         name = string.gsub(name, "%%", "%%%%")
     end
     local level = lib_characters.GetPlayerLevel(address)

--- a/Player Reader/init.lua
+++ b/Player Reader/init.lua
@@ -248,7 +248,11 @@ local function PresentPlayers()
         local index = playerList[i].index
         local address = playerList[i].address
 
-        local name = string.gsub(lib_characters.GetPlayerName(address), "%%", "%%%%")
+        local name = lib_characters.GetPlayerName(address)
+        -- Escape '%' in the name but only if the plugin isn't updated
+        if pso.require_version == nil or not pso.require_version(3, 5, 0) then
+            name = string.gsub(name, "%%", "%%%%")
+        end
         local hp = lib_characters.GetPlayerHP(address)
         local mhp = lib_characters.GetPlayerMaxHP(address)
         local hpColor = lib_helpers.HPToGreenRedGradient(hp/mhp)
@@ -258,7 +262,7 @@ local function PresentPlayers()
 
         lib_helpers.Text(true, "%2i", index)
         imgui.NextColumn()
-        lib_helpers.Text(true, name)
+        lib_helpers.Text(true, "%s", name)
         imgui.NextColumn()
         lib_helpers.imguiProgressBar(true, hp/mhp, -1.0, imgui.GetFontSize(), hpColor, nil, hp)
         imgui.NextColumn()
@@ -286,7 +290,11 @@ local function PresentPlayer(address, sd, inv, showName, HPbar, showBarMaxValue,
         return
     end
 
-    local name = string.gsub(lib_characters.GetPlayerName(address), "%%", "%%%%")
+    local name = lib_characters.GetPlayerName(address)
+    -- Escape '%' in the name but only if the plugin isn't updated
+    if pso.require_version == nil or not pso.require_version(3, 5, 0) then
+        name = string.gsub(name, "%%", "%%%%")
+    end
     local level = lib_characters.GetPlayerLevel(address)
     local hp = lib_characters.GetPlayerHP(address)
     local mhp = lib_characters.GetPlayerMaxHP(address)

--- a/solylib/characters.lua
+++ b/solylib/characters.lua
@@ -170,8 +170,16 @@ local function GetPlayerParalyzedStatus(player)
     return pso.read_u32(player + 0x25C) == 0x10
 end
 
+-- Returns the floor the player is on. This works well enough for other players, but
+-- use GetCurrentFloorSelf() for the local client if you need the floor to be consistent
+-- with other entities or data.
 local function GetPlayerFloor(player)
-    return pso.read_u32(player + 0x3f0)
+    return pso.read_u32(player + 0x3F0)
+end
+
+-- Gets the actual floor we are on. This is consistent with the active entities.
+local function GetCurrentFloorSelf()
+    return pso.read_u32(0xAAFCA0)
 end
 
 local function GetPlayerIsCast(player)
@@ -207,4 +215,5 @@ return
     GetPlayerIsCast = GetPlayerIsCast,    
     Techniques = Techniques,
     GetPlayerFloor = GetPlayerFloor,
+    GetCurrentFloorSelf = GetCurrentFloorSelf,
 }

--- a/solylib/characters.lua
+++ b/solylib/characters.lua
@@ -170,6 +170,10 @@ local function GetPlayerParalyzedStatus(player)
     return pso.read_u32(player + 0x25C) == 0x10
 end
 
+local function GetPlayerFloor(player)
+    return pso.read_u32(player + 0x3f0)
+end
+
 local function GetPlayerIsCast(player)
     local result = false
     local equipFlags = pso.read_u8(player + 0x964)
@@ -202,4 +206,5 @@ return
     GetPlayerParalyzedStatus = GetPlayerParalyzedStatus,
     GetPlayerIsCast = GetPlayerIsCast,    
     Techniques = Techniques,
+    GetPlayerFloor = GetPlayerFloor,
 }

--- a/solylib/items/items.lua
+++ b/solylib/items/items.lua
@@ -569,7 +569,11 @@ local function GetMultiFloorItemList(inverted)
         return itemTable
     end
 
-    local myFloor = lib_characters.GetPlayerFloor(lib_characters.GetSelf())
+    local myPlayer = lib_characters.GetSelf()
+    local myFloor = -1
+    if myPlayer ~= 0 then
+        myFloor = lib_characters.GetPlayerFloor(myPlayer)
+    end
     -- Loop through all floor numbers and read the stored floor items.
     -- Note that PSOBB has a limit on a vanilla client for number of items
     -- stored. But the current floor's items are generated on demand regardless

--- a/solylib/items/items.lua
+++ b/solylib/items/items.lua
@@ -569,11 +569,8 @@ local function GetMultiFloorItemList(inverted)
         return itemTable
     end
 
-    local myPlayer = lib_characters.GetSelf()
-    local myFloor = -1
-    if myPlayer ~= 0 then
-        myFloor = lib_characters.GetPlayerFloor(myPlayer)
-    end
+    local myFloor = lib_characters.GetCurrentFloorSelf()
+    
     -- Loop through all floor numbers and read the stored floor items.
     -- Note that PSOBB has a limit on a vanilla client for number of items
     -- stored. But the current floor's items are generated on demand regardless

--- a/solylib/items/items.lua
+++ b/solylib/items/items.lua
@@ -1,5 +1,6 @@
 local pmt = require("solylib.pmt")
 local unitxt = require("solylib.unitxt")
+local lib_characters = require("solylib.characters")
 
 local _ItemArray = 0x00A8D81C
 local _ItemArrayCount = 0x00A8D820
@@ -463,6 +464,158 @@ local function GetItemList(playerIndex, inverted)
     return itemTable
 end
 
+-- Reads the item data for an item in the floor storage. The floor storage
+-- contains only the 16 bytes of item data, item ID, and positional data.
+local function ReadMultiFloorItemData(itemAddr, floorNumber)
+    local _MultiFloorItemDataOffset = 0x10
+    local _MultiFloorItemData2Offset = 0x20
+    local _MultiFloorItemIDOffset = 0x1C
+    local _MultiFloorItemKills = 0x1A
+
+    local item = {}
+    item.address = itemAddr
+    item.floorNumber = floorNumber
+
+    item.data = {0,0,0,0,0,0,0,0,0,0,0,0}
+
+    item.id = pso.read_u32(itemAddr + _MultiFloorItemIDOffset)
+
+    item.data[1] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 0)
+    item.data[2] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 1)
+    item.data[3] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 2)
+    item.data[4] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 3)
+    item.data[5] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 4)
+    item.data[6] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset+ 5)
+    item.data[7] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 6)
+    item.data[8] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 7)
+    item.data[9] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 8)
+    item.data[10] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 9)
+    item.data[11] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 10)
+    item.data[12] = pso.read_u8(itemAddr + _MultiFloorItemDataOffset + 11)
+    item.data[13] = pso.read_u8(itemAddr + _MultiFloorItemData2Offset + 0)
+    item.data[14] = pso.read_u8(itemAddr + _MultiFloorItemData2Offset + 1)
+    item.data[15] = pso.read_u8(itemAddr + _MultiFloorItemData2Offset + 2)
+    item.data[16] = pso.read_u8(itemAddr + _MultiFloorItemData2Offset + 3)
+
+    item.hex = bit.lshift(item.data[1], 16) + bit.lshift(item.data[2],  8) + item.data[3]
+    item.kills = 0
+    item.equipped = false
+
+    item.name = unitxt.GetItemName(pmt.GetItemUnitxtID(item.data))
+
+    -- WEAPON
+    if item.data[1] == 0 then
+        item.weapon = {}
+
+        if item.data[2] == 0x33 or item.data[2] == 0xAB then
+            item.kills = pso.read_u16(itemAddr + _MultiFloorItemKills)
+        end
+
+        item = _ParseItemWeapon(item)
+    -- ARMOR
+    elseif item.data[1] == 1 then
+        -- FRAME
+        if item.data[2] == 1 then
+            item.armor = {}
+
+            item = _ParseItemFrame(item)
+        -- BARRIER
+        elseif item.data[2] == 2 then
+            item.armor = {}
+
+            item = _ParseItemBarrier(item)
+        -- UNIT
+        elseif item.data[2] == 3 then
+            item.unit = {}
+
+            if item.data[3] == 0x4D or item.data[3] == 0x4F then
+                item.kills = pso.read_u16(itemAddr + _MultiFloorItemKills)
+            end
+
+            item = _ParseItemUnit(item)
+        end
+    -- MAG
+    elseif item.data[1] == 2 then
+        item.mag = {}
+
+        -- No mag timer available for mags on other floors. Could maybe lookup the 
+        -- mag in the local floor items array if the item is on current floor.
+        item.mag.timer = 210 -- 3 minutes and 30 seconds
+        --item.mag.timer = pso.read_f32(itemAddr + _ItemMagTimer) / 30
+
+        item = _ParseItemMag(item)
+    -- TOOL
+    elseif item.data[1] == 3 then
+        item.tool = {}
+        if item.data[2] == 2 then
+            item = _ParseItemTechnique(item)
+        else
+            item = _ParseItemTool(item)
+        end
+    -- MESETA
+    elseif item.data[1] == 4 then
+        item = _ParseItemMeseta(item)
+    end
+
+    return item
+end
+
+local function GetMultiFloorItemList(inverted)
+    local ptrsToFloorsArray = pso.read_u32(0xA8D8A0)
+    local itemsPerFloorArray = pso.read_u32(0xA8D89C)
+    local itemTable = {}
+    local itemIndex = 0
+    if (0 == ptrsToFloorsArray or 0 == itemsPerFloorArray) then
+        return itemTable
+    end
+
+    local myFloor = lib_characters.GetPlayerFloor(lib_characters.GetSelf())
+    -- Loop through all floor numbers and read the stored floor items.
+    -- Note that PSOBB has a limit on a vanilla client for number of items
+    -- stored. But the current floor's items are generated on demand regardless
+    -- of that storage limit. So for the current floor, read the item list using
+    -- the regular code.
+    for i=0,17 do 
+        if myFloor == i then
+            local currentFloorItems = GetItemList(NoOwner, inverted)
+            -- Append to the table 
+            for _,v in pairs(currentFloorItems) do
+                table.insert(itemTable, v)
+            end
+        else
+            local thisFloorsItems = pso.read_u32(ptrsToFloorsArray + 4 * i)
+            local thisFloorsNumItems = pso.read_u32(itemsPerFloorArray + i * 4) 
+            local startIndex = 0
+            local endIndex = thisFloorsNumItems - 1 -- lua is 1-based...
+            for j=startIndex,endIndex,1 do 
+                local itemAddr = thisFloorsItems + j * 0x24
+                local item = ReadMultiFloorItemData(itemAddr, i)
+                table.insert(itemTable, item)
+            end
+        end
+    end
+
+    -- sort table by IDs. Since it's only floor items, no need to care about owner.
+    local sortFunction = 
+        function (left, right)
+            if inverted then 
+                return left.id > right.id
+            else
+                return left.id < right.id
+            end
+        end
+
+    -- Sort the items in order by item ID. IDs are unique in the room so with 'inverted' set,
+    -- the newest drops in the party would be at the top.
+    table.sort(itemTable, sortFunction)
+    -- Item index isn't very useful but for the Floor Reader on a single floor, it's just
+    -- 1..max. Maintain that here because otherwise the indices are out of order.
+    for itemIndex=1,#itemTable do
+        itemTable[itemIndex].index = itemIndex
+    end
+    return itemTable
+end
+
 -- Reads a player's inventory (meseta and items)
 -- If owner(index) is -2, the function will automatically obtain the client's playerIndex
 local function GetInventory(playerIndex)
@@ -538,4 +691,5 @@ return
     GetItemList = GetItemList,
     GetInventory = GetInventory,
     GetBank = GetBank,
+    GetMultiFloorItemList = GetMultiFloorItemList,
 }


### PR DESCRIPTION
Multi-floor option shows items on all floors and sorts the items according to item ID. The items on other floors can be displayed using a 'brightness percent' to make them darker, or a string can be prepended to the beginning of the line to differentiate.

Changed handling of '%' character in Item Reader and Player Reader because the next version of the base plugin should properly format strings passed to various ImGui functions with variadic argument support.