### PR TITLE
Add options to hide windows when menus are open

### DIFF
--- a/Item Reader/configuration.lua
+++ b/Item Reader/configuration.lua
@@ -98,6 +98,19 @@ local function ConfigurationWindow(configuration)
                 this.changed = true
             end
 
+            if imgui.Checkbox("Hide when menus are open", _configuration.aio.HideWhenMenu) then
+                _configuration.aio.HideWhenMenu = not _configuration.aio.HideWhenMenu
+                this.changed = true
+            end
+            if imgui.Checkbox("Hide when symbol chat/word select is open", _configuration.aio.HideWhenSymbolChat) then
+                _configuration.aio.HideWhenSymbolChat = not _configuration.aio.HideWhenSymbolChat
+                this.changed = true
+            end
+            if imgui.Checkbox("Hide when the menu is unavailable", _configuration.aio.HideWhenMenuUnavailable) then
+                _configuration.aio.HideWhenMenuUnavailable = not _configuration.aio.HideWhenMenuUnavailable
+                this.changed = true
+            end
+
             if imgui.Checkbox("No title bar", _configuration.aio.NoTitleBar == "NoTitleBar") then
                 if _configuration.aio.NoTitleBar == "NoTitleBar" then
                     _configuration.aio.NoTitleBar = ""

--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -3,6 +3,7 @@ local lib_helpers = require("solylib.helpers")
 local lib_characters = require("solylib.characters")
 local lib_unitxt = require("solylib.unitxt")
 local lib_items = require("solylib.items.items")
+local lib_menu = require("solylib.menu")
 local lib_items_list = require("solylib.items.items_list")
 local lib_items_cfg = require("solylib.items.items_configuration")
 local cfg = require("Item Reader.configuration")
@@ -33,41 +34,44 @@ if optionsLoaded then
     if options.aio == nil or type(options.aio) ~= "table" then
         options.aio = {}
     end
-    options.aio.EnableWindow         = lib_helpers.NotNilOrDefault(options.aio.EnableWindow, true)
-    options.aio.changed              = lib_helpers.NotNilOrDefault(options.aio.changed, true)
-    options.aio.Anchor               = lib_helpers.NotNilOrDefault(options.aio.Anchor, 1)
-    options.aio.X                    = lib_helpers.NotNilOrDefault(options.aio.X, 50)
-    options.aio.Y                    = lib_helpers.NotNilOrDefault(options.aio.Y, 5)
-    options.aio.W                    = lib_helpers.NotNilOrDefault(options.aio.W, 450)
-    options.aio.H                    = lib_helpers.NotNilOrDefault(options.aio.H, 350)
-    options.aio.NoTitleBar           = lib_helpers.NotNilOrDefault(options.aio.NoTitleBar, "")
-    options.aio.NoResize             = lib_helpers.NotNilOrDefault(options.aio.NoResize, "")
-    options.aio.NoMove               = lib_helpers.NotNilOrDefault(options.aio.NoMove, "")
-    options.aio.AlwaysAutoResize     = lib_helpers.NotNilOrDefault(options.aio.AlwaysAutoResize, "")
-    options.aio.TransparentWindow    = lib_helpers.NotNilOrDefault(options.aio.TransparentWindow, false)
-    options.aio.ShowButtonSaveToFile = lib_helpers.NotNilOrDefault(options.aio.ShowButtonSaveToFile, true)
-    options.aio.SelectedInventory    = lib_helpers.NotNilOrDefault(options.aio.SelectedInventory, 1)
+    options.aio.EnableWindow            = lib_helpers.NotNilOrDefault(options.aio.EnableWindow, true)
+    options.aio.HideWhenMenu            = lib_helpers.NotNilOrDefault(options.aio.HideWhenMenu, true)
+    options.aio.HideWhenSymbolChat      = lib_helpers.NotNilOrDefault(options.aio.HideWhenSymbolChat, true)
+    options.aio.HideWhenMenuUnavailable = lib_helpers.NotNilOrDefault(options.aio.HideWhenMenuUnavailable, true)
+    options.aio.changed                 = lib_helpers.NotNilOrDefault(options.aio.changed, true)
+    options.aio.Anchor                  = lib_helpers.NotNilOrDefault(options.aio.Anchor, 1)
+    options.aio.X                       = lib_helpers.NotNilOrDefault(options.aio.X, 50)
+    options.aio.Y                       = lib_helpers.NotNilOrDefault(options.aio.Y, 5)
+    options.aio.W                       = lib_helpers.NotNilOrDefault(options.aio.W, 450)
+    options.aio.H                       = lib_helpers.NotNilOrDefault(options.aio.H, 350)
+    options.aio.NoTitleBar              = lib_helpers.NotNilOrDefault(options.aio.NoTitleBar, "")
+    options.aio.NoResize                = lib_helpers.NotNilOrDefault(options.aio.NoResize, "")
+    options.aio.NoMove                  = lib_helpers.NotNilOrDefault(options.aio.NoMove, "")
+    options.aio.AlwaysAutoResize        = lib_helpers.NotNilOrDefault(options.aio.AlwaysAutoResize, "")
+    options.aio.TransparentWindow       = lib_helpers.NotNilOrDefault(options.aio.TransparentWindow, false)
+    options.aio.ShowButtonSaveToFile    = lib_helpers.NotNilOrDefault(options.aio.ShowButtonSaveToFile, true)
+    options.aio.SelectedInventory       = lib_helpers.NotNilOrDefault(options.aio.SelectedInventory, 1)
 
     if options.floor == nil or type(options.floor) ~= "table" then
         options.floor = {}
     end
-    options.floor.EnableWindow       = lib_helpers.NotNilOrDefault(options.floor.EnableWindow, true)
-    options.floor.changed            = lib_helpers.NotNilOrDefault(options.floor.changed, true)
-    options.floor.Anchor             = lib_helpers.NotNilOrDefault(options.floor.Anchor, 1)
-    options.floor.X                  = lib_helpers.NotNilOrDefault(options.floor.X, 50)
-    options.floor.Y                  = lib_helpers.NotNilOrDefault(options.floor.Y, 50)
-    options.floor.W                  = lib_helpers.NotNilOrDefault(options.floor.W, 450)
-    options.floor.H                  = lib_helpers.NotNilOrDefault(options.floor.H, 350)
-    options.floor.NoTitleBar         = lib_helpers.NotNilOrDefault(options.floor.NoTitleBar, "")
-    options.floor.NoResize           = lib_helpers.NotNilOrDefault(options.floor.NoResize, "")
-    options.floor.NoMove             = lib_helpers.NotNilOrDefault(options.floor.NoMove, "")
-    options.floor.AlwaysAutoResize   = lib_helpers.NotNilOrDefault(options.floor.AlwaysAutoResize, "")
-    options.floor.TransparentWindow  = lib_helpers.NotNilOrDefault(options.floor.TransparentWindow, false)
-    options.floor.ShowInvMesetaAndItemCount = lib_helpers.NotNilOrDefault(options.floor.ShowInvMesetaAndItemCount, false)
-    options.floor.ShowMultiFloor     = lib_helpers.NotNilOrDefault(options.floor.ShowMultiFloor, false)
+    options.floor.EnableWindow                 = lib_helpers.NotNilOrDefault(options.floor.EnableWindow, true)
+    options.floor.changed                      = lib_helpers.NotNilOrDefault(options.floor.changed, true)
+    options.floor.Anchor                       = lib_helpers.NotNilOrDefault(options.floor.Anchor, 1)
+    options.floor.X                            = lib_helpers.NotNilOrDefault(options.floor.X, 50)
+    options.floor.Y                            = lib_helpers.NotNilOrDefault(options.floor.Y, 50)
+    options.floor.W                            = lib_helpers.NotNilOrDefault(options.floor.W, 450)
+    options.floor.H                            = lib_helpers.NotNilOrDefault(options.floor.H, 350)
+    options.floor.NoTitleBar                   = lib_helpers.NotNilOrDefault(options.floor.NoTitleBar, "")
+    options.floor.NoResize                     = lib_helpers.NotNilOrDefault(options.floor.NoResize, "")
+    options.floor.NoMove                       = lib_helpers.NotNilOrDefault(options.floor.NoMove, "")
+    options.floor.AlwaysAutoResize             = lib_helpers.NotNilOrDefault(options.floor.AlwaysAutoResize, "")
+    options.floor.TransparentWindow            = lib_helpers.NotNilOrDefault(options.floor.TransparentWindow, false)
+    options.floor.ShowInvMesetaAndItemCount    = lib_helpers.NotNilOrDefault(options.floor.ShowInvMesetaAndItemCount, false)
+    options.floor.ShowMultiFloor               = lib_helpers.NotNilOrDefault(options.floor.ShowMultiFloor, false)
     options.floor.OtherFloorsBrightnessPercent = lib_helpers.NotNilOrDefault(options.floor.OtherFloorsBrightnessPercent, 100)
-    options.floor.OtherFloorsPrependString = lib_helpers.NotNilOrDefault(options.floor.OtherFloorsPrependString, "")
-    options.floor.EnableFilters      = lib_helpers.NotNilOrDefault(options.floor.EnableFilters, false)
+    options.floor.OtherFloorsPrependString     = lib_helpers.NotNilOrDefault(options.floor.OtherFloorsPrependString, "")
+    options.floor.EnableFilters                = lib_helpers.NotNilOrDefault(options.floor.EnableFilters, false)
 
     if options.floor.filter == nil or type(options.floor.filter) ~= "table" then
         options.floor.filter = {}
@@ -133,6 +137,9 @@ else
         server = 1,
         aio = {
             EnableWindow = true,
+            HideWhenMenu = false,
+            HideWhenSymbolChat = false,
+            HideWhenMenuUnavailable = false,
             changed = true,
             Anchor = 1,
             X = 50,
@@ -237,6 +244,9 @@ local function SaveOptions(options)
         io.write(string.format("    updateThrottle = %i,\n", tostring(options.updateThrottle)))
         io.write(string.format("    aio = {\n"))
         io.write(string.format("        EnableWindow = %s,\n", tostring(options.aio.EnableWindow)))
+        io.write(string.format("        HideWhenMenu = %s,\n", tostring(options.aio.HideWhenMenu)))
+        io.write(string.format("        HideWhenSymbolChat = %s,\n", tostring(options.aio.HideWhenSymbolChat)))
+        io.write(string.format("        HideWhenMenuUnavailable = %s,\n", tostring(options.aio.HideWhenMenuUnavailable)))
         io.write(string.format("        Anchor = %i,\n", options.aio.Anchor))
         io.write(string.format("        X = %i,\n", options.aio.X))
         io.write(string.format("        Y = %i,\n", options.aio.Y))
@@ -1166,7 +1176,11 @@ local function present()
     --- Update timer for update throttle
     current_time = pso.get_tick_count()
 
-    if options.aio.EnableWindow then
+    if (options.aio.EnableWindow == true)
+        and (options.aio.HideWhenMenu == false or lib_menu.IsMenuOpen() == false)
+        and (options.aio.HideWhenSymbolChat == false or lib_menu.IsSymbolChatOpen() == false)
+        and (options.aio.HideWhenMenuUnavailable == false or lib_menu.IsMenuUnavailable() == false)
+    then
         local windowName = "Item Reader - AIO"
 
         if options.aio.TransparentWindow == true then

--- a/Monster Reader/configuration.lua
+++ b/Monster Reader/configuration.lua
@@ -49,6 +49,19 @@ local function ConfigurationWindow(configuration)
                 this.changed = true
             end
 
+            if imgui.Checkbox("Hide when menus are open", _configuration.mhpHideWhenMenu) then
+                _configuration.mhpHideWhenMenu = not _configuration.mhpHideWhenMenu
+                this.changed = true
+            end
+            if imgui.Checkbox("Hide when symbol chat/word select is open", _configuration.mhpHideWhenSymbolChat) then
+                _configuration.mhpHideWhenSymbolChat = not _configuration.mhpHideWhenSymbolChat
+                this.changed = true
+            end
+            if imgui.Checkbox("Hide when the menu is unavailable", _configuration.mhpHideWhenMenuUnavailable) then
+                _configuration.mhpHideWhenMenuUnavailable = not _configuration.mhpHideWhenMenuUnavailable
+                this.changed = true
+            end
+
             if imgui.Checkbox("No title bar", _configuration.mhpNoTitleBar == "NoTitleBar") then
                 if _configuration.mhpNoTitleBar == "NoTitleBar" then
                     _configuration.mhpNoTitleBar = ""

--- a/Monster Reader/init.lua
+++ b/Monster Reader/init.lua
@@ -3,6 +3,7 @@ local lib_helpers = require("solylib.helpers")
 local lib_characters = require("solylib.characters")
 local lib_unitxt = require("solylib.unitxt")
 local lib_items = require("solylib.items.items")
+local lib_menu = require("solylib.menu")
 local cfg = require("Monster Reader.configuration")
 local cfgMonsters = require("Monster Reader.monsters")
 local optionsLoaded, options = pcall(require, "Monster Reader.options")
@@ -20,17 +21,20 @@ if optionsLoaded then
     options.showMonsterStatus         = lib_helpers.NotNilOrDefault(options.showMonsterStatus, false)
     options.showMonsterID             = lib_helpers.NotNilOrDefault(options.showMonsterID, false)
 
-    options.mhpEnableWindow      = lib_helpers.NotNilOrDefault(options.mhpEnableWindow, true)
-    options.mhpChanged           = lib_helpers.NotNilOrDefault(options.mhpChanged, false)
-    options.mhpAnchor            = lib_helpers.NotNilOrDefault(options.mhpAnchor, 1)
-    options.mhpX                 = lib_helpers.NotNilOrDefault(options.mhpX, 50)
-    options.mhpY                 = lib_helpers.NotNilOrDefault(options.mhpY, 50)
-    options.mhpW                 = lib_helpers.NotNilOrDefault(options.mhpW, 450)
-    options.mhpH                 = lib_helpers.NotNilOrDefault(options.mhpH, 350)
-    options.mhpNoTitleBar        = lib_helpers.NotNilOrDefault(options.mhpNoTitleBar, "")
-    options.mhpNoResize          = lib_helpers.NotNilOrDefault(options.mhpNoResize, "")
-    options.mhpNoMove            = lib_helpers.NotNilOrDefault(options.mhpNoMove, "")
-    options.mhpTransparentWindow = lib_helpers.NotNilOrDefault(options.mhpTransparentWindow, false)
+    options.mhpEnableWindow            = lib_helpers.NotNilOrDefault(options.mhpEnableWindow, true)
+    options.mhpHideWhenMenu            = lib_helpers.NotNilOrDefault(options.mhpHideWhenMenu, true)
+    options.mhpHideWhenSymbolChat      = lib_helpers.NotNilOrDefault(options.mhpHideWhenSymbolChat, true)
+    options.mhpHideWhenMenuUnavailable = lib_helpers.NotNilOrDefault(options.mhpHideWhenMenuUnavailable, true)
+    options.mhpChanged                 = lib_helpers.NotNilOrDefault(options.mhpChanged, false)
+    options.mhpAnchor                  = lib_helpers.NotNilOrDefault(options.mhpAnchor, 1)
+    options.mhpX                       = lib_helpers.NotNilOrDefault(options.mhpX, 50)
+    options.mhpY                       = lib_helpers.NotNilOrDefault(options.mhpY, 50)
+    options.mhpW                       = lib_helpers.NotNilOrDefault(options.mhpW, 450)
+    options.mhpH                       = lib_helpers.NotNilOrDefault(options.mhpH, 350)
+    options.mhpNoTitleBar              = lib_helpers.NotNilOrDefault(options.mhpNoTitleBar, "")
+    options.mhpNoResize                = lib_helpers.NotNilOrDefault(options.mhpNoResize, "")
+    options.mhpNoMove                  = lib_helpers.NotNilOrDefault(options.mhpNoMove, "")
+    options.mhpTransparentWindow       = lib_helpers.NotNilOrDefault(options.mhpTransparentWindow, false)
 
     options.targetEnableWindow          = lib_helpers.NotNilOrDefault(options.targetEnableWindow, true)
     options.targetChanged               = lib_helpers.NotNilOrDefault(options.targetChanged, false)
@@ -71,6 +75,9 @@ else
         showMonsterID = false,
 
         mhpEnableWindow = true,
+        mhpHideWhenMenu = false,
+        mhpHideWhenSymbolChat = false,
+        mhpHideWhenMenuUnavailable = false,
         mhpChanged = false,
         mhpAnchor = 1,
         mhpX = 50,
@@ -126,6 +133,9 @@ local function SaveOptions(options)
         io.write(string.format("    showMonsterID = %s,\n", tostring(options.showMonsterID)))
         io.write("\n")
         io.write(string.format("    mhpEnableWindow = %s,\n", tostring(options.mhpEnableWindow)))
+        io.write(string.format("    mhpHideWhenMenu = %s,\n", tostring(options.mhpHideWhenMenu)))
+        io.write(string.format("    mhpHideWhenSymbolChat = %s,\n", tostring(options.mhpHideWhenSymbolChat)))
+        io.write(string.format("    mhpHideWhenMenuUnavailable = %s,\n", tostring(options.mhpHideWhenMenuUnavailable)))
         io.write(string.format("    mhpChanged = %s,\n", tostring(options.mhpChanged)))
         io.write(string.format("    mhpAnchor = %i,\n", options.mhpAnchor))
         io.write(string.format("    mhpX = %i,\n", options.mhpX))
@@ -889,23 +899,24 @@ local function present()
         return
     end
 
-    if options.mhpEnableWindow then
+    if (options.mhpEnableWindow == true)
+        and (options.mhpHideWhenMenu == false or lib_menu.IsMenuOpen() == false)
+        and (options.mhpHideWhenSymbolChat == false or lib_menu.IsSymbolChatOpen() == false)
+        and (options.mhpHideWhenMenuUnavailable == false or lib_menu.IsMenuUnavailable() == false)
+    then
         if firstPresent or options.mhpChanged then
             options.mhpChanged = false
             local ps = lib_helpers.GetPosBySizeAndAnchor(options.mhpX, options.mhpY, options.mhpW, options.mhpH, options.mhpAnchor)
             imgui.SetNextWindowPos(ps[1], ps[2], "Always");
             imgui.SetNextWindowSize(options.mhpW, options.mhpH, "Always");
         end
-
         if options.mhpTransparentWindow == true then
             imgui.PushStyleColor("WindowBg", 0.0, 0.0, 0.0, 0.0)
         end
-
         if imgui.Begin("Monster Reader - HP", nil, { options.mhpNoTitleBar, options.mhpNoResize, options.mhpNoMove }) then
             PresentMonsters()
         end
         imgui.End()
-
         if options.mhpTransparentWindow == true then
             imgui.PopStyleColor()
         end


### PR DESCRIPTION
Add options for Monster HP and AIO to hide when menus are open (disabled by default).

This allows greater flexibility in positioning addon windows without covering up in-game menus.