### PR TITLE
Hit minimum option

### DIFF
--- a/Item Reader/configuration.lua
+++ b/Item Reader/configuration.lua
@@ -331,7 +331,15 @@ local function ConfigurationWindow(configuration)
             if _configuration.floor.EnableFilters then
                 if imgui.TreeNodeEx("Filter Drops") then
                     imgui.Text("Non-Rares")
-                    if imgui.Checkbox("Hide <40h Weapons", _configuration.floor.filter.HideLowHitWeapons) then
+                    
+                   	imgui.PushItemWidth(110)
+					success, _configuration.floor.filter.HitMin = imgui.InputInt("Minimum Hit", _configuration.floor.filter.HitMin)
+					imgui.PopItemWidth()
+					if success then
+						this.changed = true
+					end
+                    
+                    if imgui.Checkbox("Hide Low Hit Weapons", _configuration.floor.filter.HideLowHitWeapons) then
                         _configuration.floor.filter.HideLowHitWeapons = not _configuration.floor.filter.HideLowHitWeapons
                         _configuration.floor.changed = true
                         this.changed = true

--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -80,6 +80,7 @@ if optionsLoaded then
     if options.floor.filter == nil or type(options.floor.filter) ~= "table" then
         options.floor.filter = {}
     end
+    options.floor.filter.HitMin			    = lib_helpers.NotNilOrDefault(options.floor.filter.HitMin, 40)
     options.floor.filter.HideLowHitWeapons  = lib_helpers.NotNilOrDefault(options.floor.filter.HideLowHitWeapons, false)
     options.floor.filter.HideLowSocketArmor = lib_helpers.NotNilOrDefault(options.floor.filter.HideLowSocketArmor, false)
     options.floor.filter.HideUselessUnits   = lib_helpers.NotNilOrDefault(options.floor.filter.HideUselessUnits, false)
@@ -190,6 +191,7 @@ else
             OtherFloorsPrependString = "",
             EnableFilters = false,
             filter = {
+                HitMin = 40,
                 HideLowHitWeapons = false,
                 HideLowSocketArmor = false,
                 HideUselessUnits = false,
@@ -310,6 +312,7 @@ local function SaveOptions(options)
         io.write(string.format("        OtherFloorsPrependString = \"%s\",\n", options.floor.OtherFloorsPrependString))
         io.write(string.format("        EnableFilters = %s,\n", options.floor.EnableFilters))
         io.write(string.format("        filter = {\n"))
+        io.write(string.format("            HitMin = %s,\n", options.floor.filter.HitMin))
         io.write(string.format("            HideLowHitWeapons = %s,\n", options.floor.filter.HideLowHitWeapons))
         io.write(string.format("            HideLowSocketArmor = %s,\n", options.floor.filter.HideLowSocketArmor))
         io.write(string.format("            HideUselessUnits = %s,\n", options.floor.filter.HideUselessUnits))
@@ -496,7 +499,7 @@ local function ProcessWeapon(item, floor)
         elseif floor and options.floor.EnableFilters and options.floor.filter.HideLowHitWeapons then
             show_item = false
             -- Hide weapon drops with less then 40h untekked
-            if item.weapon.stats[6] >= 40 then
+            if item.weapon.stats[6] >= options.floor.filter.HitMin then
                 show_item = true
             end
         end


### PR DESCRIPTION
Adds a numerical option to set the minimum hit value for the floor item reader, rather than being locked to 40.
I've never used this site before so sorry if I'm doing something wrong here!