### PR TITLE
Update reading of _EntityArray to allow for clients that patched refe…

### DIFF
--- a/Monster Reader/init.lua
+++ b/Monster Reader/init.lua
@@ -196,7 +196,7 @@ local _targetPointerOffset = 0x18
 local _targetOffset = 0x108C
 
 local _EntityCount = 0x00AAE164
-local _EntityArray = 0x00AAD720
+local _EntityArray = pso.read_u32(0x7B4BA0 + 2) -- Reads the address out of initialization instruction
 
 local _MonsterUnitxtID = 0x378
 local _MonsterHP = 0x334


### PR DESCRIPTION
…rences to the array. The _EntityArray is a global in the client with a max size of 652 elements. This is really small in some areas such as Subterranean Desert 2 where objects in the d.dat create hundreds of extra entities. This small array causes crashes when the 50 item floor limit from the vanilla game isn't enforced properly (such as individual drop style or shared drops but the host is on a different floor). 