### PR TITLE
Fix crash caused by fetching mag photon blast names at the main menu …

### DIFF
--- a/solylib/items/items.lua
+++ b/solylib/items/items.lua
@@ -383,8 +383,6 @@ local function ReadItemData(itemAddr)
 end
 
 local function ReadBankItemData(itemAddr)
-    local _BankItemKillCount1 = 0x0A
-    local _BankItemKillCount2 = 0x0B
     local item = {}
     item.address = itemAddr
 

--- a/solylib/items/items.lua
+++ b/solylib/items/items.lua
@@ -63,11 +63,11 @@ end
 local function GetKillCountFromItemData(item)
     -- Offset because lua is 1-based...
     local offset = 1
-    
+
     -- kill count is in big endian. Read both bytes and convert
     -- TODO: Could kill count be stored somewhere else in the item data? In another attr slot?
-    local b1 = item.data[offset + 0x0A]
-    local b2 = item.data[offset + 0x0B]
+    local b1 = item.data[offset + 0x0A] or 0
+    local b2 = item.data[offset + 0x0B] or 0 
     local dataKills = bit.bor(bit.lshift(b1, 8), b2)
 
     if bit.band(dataKills, 0x8000) == 0 then

--- a/solylib/unitxt.lua
+++ b/solylib/unitxt.lua
@@ -18,7 +18,9 @@ local magColor =
     "Fuchsia", "Grey", "Cream", "Pink", "Dark Green",
 }
 
--- Internal function to read text from the unitxt
+-- Internal function to read text from the unitxt.
+-- Note that the unitxt is reloaded at the main menu, so this function
+-- will return nil in that case.
 local function _Read(group, index)
     local address = pso.read_u32(unitxtPointer)
     if address == 0 then
@@ -100,7 +102,8 @@ local function GetPhotonBlastName(id, shortName)
         return " "
     end
 
-    local result = _Read(9, id)
+    -- unitxt may be unloaded
+    local result = _Read(9, id) or " "
     if shortName == true then
         result = string.sub(result, 1, 1)
     end


### PR DESCRIPTION
Unitxt is unloaded for a frame at the main menu, so the AIO may crash when fetching certain strings. Item kill counters in the bank and multi-floor list were missing or bogus--this corrects them by using the item data.

Also fixed the mag timer in ReadItemData() to round up to the nearest second. This way the timer starts at 03:30 and will hit 00:00 exactly when the mag can be fed. 