### PR TITLE
Add Tech Assist Feature, Resistance Colors, and HP bar hide option

### DIFF
--- a/Monster Reader/configuration.lua
+++ b/Monster Reader/configuration.lua
@@ -149,8 +149,18 @@ local function ConfigurationWindow(configuration)
                 this.changed = true
             end
 
+            if imgui.Checkbox("Show Tech Assist", _configuration.targetShowTechAssist) then
+                _configuration.targetShowTechAssist = not _configuration.targetShowTechAssist
+                this.changed = true
+            end
+
             if imgui.Checkbox("Show Monster Stats", _configuration.targetShowMonsterStats) then
                 _configuration.targetShowMonsterStats = not _configuration.targetShowMonsterStats
+                this.changed = true
+            end
+
+            if imgui.Checkbox("Show Monster HP", _configuration.targetShowMonsterHP) then
+                _configuration.targetShowMonsterHP = not _configuration.targetShowMonsterHP
                 this.changed = true
             end
 


### PR DESCRIPTION
Change the following:
1. Add feature for tech assist.
  * Tech assist will display the enemy's weakest element and print them in order within the Target window. Eg. [Fire < Dark < Thunder < Ice < Light]
  * There is also an option to enable/disable this feature within the configuration window. 
2. Update the text display from white to colored for enemy resistances.
  * Target enemy resistances will now be shown in color (eg. EFR is in red because it's related to fire).
3. Add options to hide enemy HP bar in the Target window. 
  * Option added to remove HP bar in target window. Mostly for people who have small monitor real estate (aka steam deck users)

Pic of feature:
<img width="433" alt="techassist" src="https://github.com/Solybum/PSOBBMod-Addons/assets/55366211/8e874d54-df81-4fe6-8d04-4d08d56876a0">

