### PR TITLE
Add option to display SD as Progressbar

### DIFF
--- a/Player Reader/configuration.lua
+++ b/Player Reader/configuration.lua
@@ -113,6 +113,12 @@ local function ConfigurationWindow(configuration)
                     _configuration.allPlayersShowBuff = not _configuration.allPlayersShowBuff
                     this.changed = true
                 end
+
+                if imgui.Checkbox("Display buffs as ProgressBar", _configuration.allPlayersShowBuffProgressBar) then
+                    _configuration.allPlayersShowBuffProgressBar = not _configuration.allPlayersShowBuffProgressBar
+                    this.changed = true
+                end
+
                 imgui.TreePop()
             end
 

--- a/Player Reader/init.lua
+++ b/Player Reader/init.lua
@@ -9,6 +9,62 @@ local optionsFileName = "addons/Player Reader/options.lua"
 local firstPresent = true
 local ConfigurationWindow
 
+local function getSDMaxDuration(level)
+    local table = {
+        [1] = 40,
+        [2] = 50,
+        [3] = 60,
+        [4] = 70,
+        [5] = 80,
+        [6] = 90,
+        [7] = 100,
+        [8] = 110,
+        [9] = 120,
+        [10] = 130,
+        [11] = 140,
+        [12] = 150,
+        [13] = 160,
+        [14] = 170,
+        [15] = 180,
+        [16] = 190,
+        [17] = 200,
+        [18] = 210,
+        [19] = 220,
+        [20] = 230,
+        [21] = 240,
+        [22] = 250,
+        [23] = 260,
+        [24] = 270,
+        [25] = 280,
+        [26] = 290,
+        [27] = 300,
+        [28] = 310,
+        [29] = 320,
+        [30] = 330,
+        [33] = 360,
+        [41] = 440,
+        [61] = 640,
+        [81] = 840,
+    }
+    return table[level]
+end
+
+local function drawSDBar(tech, color)
+    local duration = getSDMaxDuration(tech.level)
+    local current = tech.time
+    lib_helpers.imguiProgressBar(
+        true,
+        current / duration,
+        -1.0,
+        imgui.GetFontSize(),
+        color,
+        nil,
+        "Lv%02i (%s): ",
+        tech.level,
+        os.date("!%M:%S", tech.time)
+    )
+end
+
 if optionsLoaded then
     -- If options loaded, make sure we have all those we need
     if options == nil or type(options) ~= "table" then
@@ -222,6 +278,7 @@ local function SaveOptions(options)
         io.write(string.format("    allPlayersShowName = %s,\n", tostring(options.allPlayersShowName)))
         io.write(string.format("    allPlayersShowHpBar = %s,\n", tostring(options.allPlayersShowHpBar)))
         io.write(string.format("    allPlayersShowBuff = %s,\n", tostring(options.allPlayersShowBuff)))
+        io.write(string.format("    allPlayersShowBuffProgressBar = %s,\n", tostring(options.allPlayersShowBuffProgressBar)))
         io.write("\n")
         io.write(string.format("    singlePlayersEnableWindow = %s,\n", tostring(options.singlePlayersEnableWindow)))
         io.write(string.format("    singlePlayersShowBarText = %s,\n", tostring(options.singlePlayersShowBarText)))
@@ -376,19 +433,26 @@ local function PresentPlayers()
         if options.allPlayersShowBuff then
             if atkTech.type == 0 then
                 lib_helpers.Text(true, "---")
+            elseif options.allPlayersShowBuffProgressBar then
+                drawSDBar(atkTech, 0xFFFF0000)
             else
                 lib_helpers.Text(true, "%s %i: %s", atkTech.name, atkTech.level, os.date("!%M:%S", atkTech.time))
             end
+
             if defTech.type == 0 then
                 lib_helpers.Text(true, "---")
+            elseif options.allPlayersShowBuffProgressBar then
+                drawSDBar(defTech, 0xFF0000FF)
             else
                 lib_helpers.Text(true, "%s %i: %s", defTech.name, defTech.level, os.date("!%M:%S", defTech.time))
             end
+
             if invuln.time == 0 then
                 lib_helpers.Text(true, "---")
             else
                 lib_helpers.Text(true, "%s: %s", "Inv.", os.date("!%M:%S", invuln.time))
             end
+
             if not options.allPlayersListHorizontal then
                 imgui.NextColumn()
             end

--- a/Player Reader/init.lua
+++ b/Player Reader/init.lua
@@ -9,44 +9,9 @@ local optionsFileName = "addons/Player Reader/options.lua"
 local firstPresent = true
 local ConfigurationWindow
 
+-- TODO: Cover this function with solylib. (discus: https://github.com/Solybum/PSOBBMod-Addons/pull/93)
 local function getSDMaxDuration(level)
-    local table = {
-        [1] = 40,
-        [2] = 50,
-        [3] = 60,
-        [4] = 70,
-        [5] = 80,
-        [6] = 90,
-        [7] = 100,
-        [8] = 110,
-        [9] = 120,
-        [10] = 130,
-        [11] = 140,
-        [12] = 150,
-        [13] = 160,
-        [14] = 170,
-        [15] = 180,
-        [16] = 190,
-        [17] = 200,
-        [18] = 210,
-        [19] = 220,
-        [20] = 230,
-        [21] = 240,
-        [22] = 250,
-        [23] = 260,
-        [24] = 270,
-        [25] = 280,
-        [26] = 290,
-        [27] = 300,
-        [28] = 310,
-        [29] = 320,
-        [30] = 330,
-        [33] = 360,
-        [41] = 440,
-        [61] = 640,
-        [81] = 840,
-    }
-    return table[level]
+    return 30 + 10 * level
 end
 
 local function drawSDBar(tech, color)


### PR DESCRIPTION
This pull request adds an option to display the remaining time of shfita/deband as a progress bar.

![Screenshot_20250601_113610](https://github.com/user-attachments/assets/b1f31862-5f55-431e-9b6b-dbff654fcce4)
![Screenshot_20250601_113656](https://github.com/user-attachments/assets/44deec11-6b0c-444b-9954-d22fed6808d9)
