### PR TITLE
fix uptekk hit bug

### DIFF
--- a/Item Reader/configuration.lua
+++ b/Item Reader/configuration.lua
@@ -370,6 +370,11 @@ local function ConfigurationWindow(configuration)
                         _configuration.floor.changed = true
                         this.changed = true
                     end
+                    if imgui.Checkbox("Hide 4 Slot Armors", _configuration.floor.filter.HideFourSocketArmor) then
+                        _configuration.floor.filter.HideFourSocketArmor = not _configuration.floor.filter.HideFourSocketArmor
+                        _configuration.floor.changed = true
+                        this.changed = true
+                    end
                     if imgui.Checkbox("Hide Useless Units", _configuration.floor.filter.HideUselessUnits) then
                         _configuration.floor.filter.HideUselessUnits = not _configuration.floor.filter.HideUselessUnits
                         _configuration.floor.changed = true

--- a/Item Reader/configuration.lua
+++ b/Item Reader/configuration.lua
@@ -370,11 +370,6 @@ local function ConfigurationWindow(configuration)
                         _configuration.floor.changed = true
                         this.changed = true
                     end
-                    if imgui.Checkbox("Hide 4 Slot Armors", _configuration.floor.filter.HideFourSocketArmor) then
-                        _configuration.floor.filter.HideFourSocketArmor = not _configuration.floor.filter.HideFourSocketArmor
-                        _configuration.floor.changed = true
-                        this.changed = true
-                    end
                     if imgui.Checkbox("Hide Useless Units", _configuration.floor.filter.HideUselessUnits) then
                         _configuration.floor.filter.HideUselessUnits = not _configuration.floor.filter.HideUselessUnits
                         _configuration.floor.changed = true

--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -88,7 +88,6 @@ if optionsLoaded then
     options.floor.filter.HideLowHitWeapons  = lib_helpers.NotNilOrDefault(options.floor.filter.HideLowHitWeapons, false)
     options.floor.filter.UptekkHit          = lib_helpers.NotNilOrDefault(options.floor.filter.UptekkHit, false)
     options.floor.filter.HideLowSocketArmor = lib_helpers.NotNilOrDefault(options.floor.filter.HideLowSocketArmor, false)
-    options.floor.filter.HideFourSocketArmor = lib_helpers.NotNilOrDefault(options.floor.filter.HideFourSocketArmor, false)
     options.floor.filter.HideUselessUnits   = lib_helpers.NotNilOrDefault(options.floor.filter.HideUselessUnits, false)
     options.floor.filter.HideUselessTechs   = lib_helpers.NotNilOrDefault(options.floor.filter.HideUselessTechs, false)
     options.floor.filter.ShowClairesDeal    = lib_helpers.NotNilOrDefault(options.floor.filter.ShowClairesDeal, false)
@@ -204,7 +203,6 @@ else
                 HitMin = 40,
                 HideLowHitWeapons = false,
                 HideLowSocketArmor = false,
-                HideFourSocketArmor = false,
                 HideUselessUnits = false,
                 HideUselessTechs = false,
                 ShowClairesDeal = false,
@@ -331,7 +329,6 @@ local function SaveOptions(options)
         io.write(string.format("            UptekkHit = %s,\n", options.floor.filter.UptekkHit))
         io.write(string.format("            HideLowHitWeapons = %s,\n", options.floor.filter.HideLowHitWeapons))
         io.write(string.format("            HideLowSocketArmor = %s,\n", options.floor.filter.HideLowSocketArmor))
-        io.write(string.format("            HideFourSocketArmor = %s \n", options.floor.filter.HideFourSocketArmor))
         io.write(string.format("            HideUselessUnits = %s,\n", options.floor.filter.HideUselessUnits))
         io.write(string.format("            HideUselessTechs = %s,\n", options.floor.filter.HideUselessTechs))
         io.write(string.format("            ShowClairesDeal = %s,\n", options.floor.filter.ShowClairesDeal))
@@ -683,7 +680,7 @@ local function ProcessFrame(item, floor)
     elseif floor and options.floor.EnableFilters and options.floor.filter.HideLowSocketArmor then
         show_item = false
         -- Show 4 socket armors
-        if item.armor.slots == 4 and not options.floor.filter.HideFourSocketArmor then
+        if item.armor.slots == 4 then
             show_item = true
         end
         -- Show Claire's Deal 5 items

--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -88,6 +88,7 @@ if optionsLoaded then
     options.floor.filter.HideLowHitWeapons  = lib_helpers.NotNilOrDefault(options.floor.filter.HideLowHitWeapons, false)
     options.floor.filter.UptekkHit          = lib_helpers.NotNilOrDefault(options.floor.filter.UptekkHit, false)
     options.floor.filter.HideLowSocketArmor = lib_helpers.NotNilOrDefault(options.floor.filter.HideLowSocketArmor, false)
+    options.floor.filter.HideFourSocketArmor = lib_helpers.NotNilOrDefault(options.floor.filter.HideFourSocketArmor, false)
     options.floor.filter.HideUselessUnits   = lib_helpers.NotNilOrDefault(options.floor.filter.HideUselessUnits, false)
     options.floor.filter.HideUselessTechs   = lib_helpers.NotNilOrDefault(options.floor.filter.HideUselessTechs, false)
     options.floor.filter.ShowClairesDeal    = lib_helpers.NotNilOrDefault(options.floor.filter.ShowClairesDeal, false)
@@ -203,6 +204,7 @@ else
                 HitMin = 40,
                 HideLowHitWeapons = false,
                 HideLowSocketArmor = false,
+                HideFourSocketArmor = false,
                 HideUselessUnits = false,
                 HideUselessTechs = false,
                 ShowClairesDeal = false,
@@ -329,6 +331,7 @@ local function SaveOptions(options)
         io.write(string.format("            UptekkHit = %s,\n", options.floor.filter.UptekkHit))
         io.write(string.format("            HideLowHitWeapons = %s,\n", options.floor.filter.HideLowHitWeapons))
         io.write(string.format("            HideLowSocketArmor = %s,\n", options.floor.filter.HideLowSocketArmor))
+        io.write(string.format("            HideFourSocketArmor = %s \n", options.floor.filter.HideFourSocketArmor))
         io.write(string.format("            HideUselessUnits = %s,\n", options.floor.filter.HideUselessUnits))
         io.write(string.format("            HideUselessTechs = %s,\n", options.floor.filter.HideUselessTechs))
         io.write(string.format("            ShowClairesDeal = %s,\n", options.floor.filter.ShowClairesDeal))
@@ -680,7 +683,7 @@ local function ProcessFrame(item, floor)
     elseif floor and options.floor.EnableFilters and options.floor.filter.HideLowSocketArmor then
         show_item = false
         -- Show 4 socket armors
-        if item.armor.slots == 4 then
+        if item.armor.slots == 4 and not options.floor.filter.HideFourSocketArmor then
             show_item = true
         end
         -- Show Claire's Deal 5 items

--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -536,7 +536,7 @@ local function ProcessWeapon(item, floor)
             end
             if options.floor.filter.UptekkHit then
                 --HANDLE UPTEKK HIT%
-                if item.weapon.untekked and item.weapon.stats[6] >= options.floor.filter.HitMin - 10 then
+                if item.weapon.untekked and item.weapon.stats[6] >= options.floor.filter.HitMin - 10 and item.weapon.stats[6] > 0 then
                     show_item = true
                 end
             end


### PR DESCRIPTION
This adds a check to ensure hit% on an untekked weapon is greater than 0 before displaying it when uptekk hit% is enabled. This resolves a bug that would occur when MinHit was set between 1-10 and any untekked weapons dropped with 0 hit. Untekked weapons with 0 hit were treated as having 10 hit when passed through the process weapon function if the uptekk hit option was enabled. 