### PR TITLE
fix uptekk hit bug

### DIFF
--- a/Item Reader/init.lua
+++ b/Item Reader/init.lua
@@ -536,7 +536,7 @@ local function ProcessWeapon(item, floor)
             end
             if options.floor.filter.UptekkHit then
                 --HANDLE UPTEKK HIT%
-                if item.weapon.untekked and item.weapon.stats[6] >= options.floor.filter.HitMin - 10 and item.weapon.stats[6] > 0 then
+                if item.weapon.untekked and item.weapon.stats[6] >= options.floor.filter.HitMin - 10 and item.weapon.stats[6] ~= 0 then
                     show_item = true
                 end
             end


### PR DESCRIPTION
This adds a check to ensure hit% on an untekked weapon is greater than 0 before displaying it when uptekk hit% is enabled. This resolves a bug that would occur when MinHit was set between 1-10 and any untekked weapons dropped with 0 hit. Untekked weapons with 0 hit were treated as having 10 hit when passed through the process weapon function if the uptekk hit option was enabled.